### PR TITLE
Fix launch by adding publish to start topic

### DIFF
--- a/launch_evaluation.bash
+++ b/launch_evaluation.bash
@@ -35,6 +35,7 @@ do
   rostopic pub /kingfisher/dodgeros_pilot/off std_msgs/Empty "{}" --once
   rostopic pub /kingfisher/dodgeros_pilot/reset_sim std_msgs/Empty "{}" --once
   rostopic pub /kingfisher/dodgeros_pilot/enable std_msgs/Bool "data: true" --once
+  rostopic pub /kingfisher/dodgeros_pilot/start std_msgs/Empty "{}" --once
 
   export ROLLOUT_NAME="rollout_""$i"
   echo "$ROLLOUT_NAME"


### PR DESCRIPTION
Add publish of empty message to the start topic to prevent having to do it by the GUI to let the drone moves