### PR TITLE
Improve the competition evaluation process

### DIFF
--- a/envtest/ros/run_competition.py
+++ b/envtest/ros/run_competition.py
@@ -21,7 +21,9 @@ class AgilePilotNode:
         rospy.init_node('agile_pilot_node', anonymous=False)
 
         self.vision_based = vision_based
-        self.ppo_path = ppo_path 
+        self.rl_policy = None
+        if ppo_path is not None:
+            self.rl_policy = load_rl_policy(ppo_path)
         self.publish_commands = False
         self.cv_bridge = CvBridge()
         self.state = None
@@ -64,10 +66,7 @@ class AgilePilotNode:
             return
         if self.state is None:
             return
-        rl_policy = None
-        if self.ppo_path is not None:
-            rl_policy = load_rl_policy(self.ppo_path)
-        command = compute_command_state_based(state=self.state, obstacles=obs_data, rl_policy=rl_policy)
+        command = compute_command_state_based(state=self.state, obstacles=obs_data, rl_policy=self.rl_policy)
         self.publish_command(command)
 
     def publish_command(self, command):

--- a/launch_evaluation.bash
+++ b/launch_evaluation.bash
@@ -49,7 +49,7 @@ do
 
   cd -
 
-  sleep 0.5
+  sleep 2.0
   rostopic pub /kingfisher/start_navigation std_msgs/Empty "{}" --once
 
   # Wait until the evaluation script has finished


### PR DESCRIPTION
Although I know it is too late to share this PR, it is still important to inform the defects in current system.

- The learned policy is re-loaded everytime when the obstacle callback func is called. I don't know the reason of such implementation, but it really takes a lot of time to deploy the trained model every time. So I refactor it to laod the policy only once.

- I increase the wait time for hovering afte takeoff, I think this is also related to the deploy the trained model. A shorter wait time would make the drone not moving.